### PR TITLE
fix importNode

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -908,11 +908,11 @@ function importNode(doc,node,deep){
 	case ELEMENT_NODE:
 		node2 = node.cloneNode(false);
 		node2.ownerDocument = doc;
-		var attrs = node2.attributes;
-		var len = attrs.length;
-		for(var i=0;i<len;i++){
-			node2.setAttributeNodeNS(importNode(doc,attrs.item(i),deep));
-		}
+		//var attrs = node2.attributes;
+		//var len = attrs.length;
+		//for(var i=0;i<len;i++){
+			//node2.setAttributeNodeNS(importNode(doc,attrs.item(i),deep));
+		//}
 	case DOCUMENT_FRAGMENT_NODE:
 		break;
 	case ATTRIBUTE_NODE:


### PR DESCRIPTION
if you try to run the below code before this fix you will get an error  Object #<Attr> has no method 'cloneNode' at importNode (c:\Temp\node_modules\xmldom\dom.js:936:16)

use this code to reproduce:

var Dom = require('xmldom').DOMParser
var doc1 = new Dom().parseFromString("<x />")
var doc2 = new Dom().parseFromString("<y xmlns=\"z\" z:p=\"1\"><p /></y>")
var n =doc1.importNode(doc2.documentElement, true)
doc1.documentElement.appendChild(n)
console.log(doc1.toString())
