### PR TITLE
Properly linked `insertBefore` with fragments.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -500,7 +500,7 @@ function _insertBefore(parentNode,newChild,nextChild){
 		cp.removeChild(newChild);//remove and update
 	}
 	if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
-		var newFirst = newChild.firstNode;
+		var newFirst = newChild.firstChild;
 		var newLast = newChild.lastChild;
 	}else{
 		newFirst = newLast = newChild;
@@ -518,12 +518,18 @@ function _insertBefore(parentNode,newChild,nextChild){
 	}
 	if(nextChild == null){
 		parentNode.lastChild = newLast;
+	}else{
+		nextChild.previousSibling = newLast;
 	}
 	do{
 		newFirst.parentNode = parentNode;
 	}while(newFirst !== newLast && (newFirst= newFirst.nextSibling))
 	_onUpdateChild(parentNode.ownerDocument||parentNode,parentNode);
 	//console.log(parentNode.lastChild.nextSibling == null)
+	if (newChild.nodeType == DOCUMENT_FRAGMENT_NODE) {
+		newChild.firstChild = newChild.lastChild = null;
+	}
+	return newChild;
 }
 function _appendSingleChild(parentNode,newChild){
 	var cp = newChild.parentNode;
@@ -543,6 +549,7 @@ function _appendSingleChild(parentNode,newChild){
 	}
 	parentNode.lastChild = newChild;
 	_onUpdateChild(parentNode.ownerDocument,parentNode,newChild);
+	return newChild;
 	//console.log("__aa",parentNode.lastChild.nextSibling == null)
 }
 Document.prototype = {
@@ -808,7 +815,7 @@ CharacterData.prototype = {
 		//if(!(newChild instanceof CharacterData)){
 			throw new Error(ExceptionMessage[3])
 		//}
-		Node.prototype.appendChild.apply(this,arguments)
+		return Node.prototype.appendChild.apply(this,arguments)
 	},
 	deleteData: function(offset, count) {
 		this.replaceData(offset,count,"");
@@ -881,6 +888,7 @@ _extends(EntityReference,Node);
 function DocumentFragment() {
 };
 DocumentFragment.prototype.nodeName =	"#document-fragment";
+DocumentFragment.prototype.nodeType =	DOCUMENT_FRAGMENT_NODE;
 _extends(DocumentFragment,Node);
 
 

--- a/test/node.js
+++ b/test/node.js
@@ -42,6 +42,43 @@ wows.describe('XML Node Parse').addBatch({
     	console.assert ( root.firstChild.nextSibling.nodeValue =='<encoded>');
     	console.assert ( root.firstChild.nextSibling.nextSibling.nextSibling.nodeValue ==' comment ');
     	console.assert ( root.firstChild.nextSibling.nextSibling.nextSibling.nextSibling.nodeValue =='end');
+    },
+    'append node': function () {
+    	var dom = new DOMParser().parseFromString('<xml/>');
+    	var child = dom.createElement("child");
+    	console.assert ( child == dom.documentElement.appendChild(child));
+    	console.assert ( child == dom.documentElement.firstChild);
+    	var fragment = new dom.createDocumentFragment();
+    	console.assert ( child == fragment.appendChild(child));
+    },
+    'insert node': function () {
+    	var dom = new DOMParser().parseFromString('<xml><child/></xml>');
+    	var node = dom.createElement("sibling");
+    	var child = dom.documentElement.firstChild;
+    	child.parentNode.insertBefore(node, child);
+    	console.assert ( node == child.previousSibling);
+    	console.assert ( node.nextSibling == child);
+    	console.assert ( node.parentNode == child.parentNode);
+    },
+    'insert fragment': function () {
+    	var dom = new DOMParser().parseFromString('<xml><child/></xml>');
+    	var fragment = dom.createDocumentFragment();
+    	assert(fragment.nodeType === 11);
+    	var first = fragment.appendChild(dom.createElement("first"));
+    	var last = fragment.appendChild(dom.createElement("last"));
+    	console.assert ( fragment.firstChild == first);
+    	console.assert ( fragment.lastChild == last);
+    	console.assert ( last.previousSibling == first);
+    	console.assert ( first.nextSibling == last);
+    	var child = dom.documentElement.firstChild;
+    	child.parentNode.insertBefore(fragment, child);
+    	console.assert ( last.previousSibling == first);
+    	console.assert ( first.nextSibling == last);
+    	console.assert ( child.parentNode.firstChild == first);
+    	console.assert ( last == child.previousSibling);
+    	console.assert ( last.nextSibling == child);
+    	console.assert ( first.parentNode == child.parentNode);
+    	console.assert ( last.parentNode == child.parentNode);
     }
 }).addBatch({
 	"instruction":function(){


### PR DESCRIPTION
Updated `insertBefore` to accept a `DocumentFragment`. Apparently, that branch of logic was not tested. It called the non-existant `Node.firstNode` instead of `Node.firstChild`.

Updated `appendChild` and `insertBefore` to return the inserted `Node` according to the WC3 DOM Level 2.

Set the `nodeType` property of `DocumentFragment` objects.

Created [an example](http://jsfiddle.net/vVKqF/2/) of what to expect when you insert a `DocumentFragment`.
