### PR TITLE
Apply namespaces to attributes immediately.

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -278,6 +278,7 @@ function appendElement(contentHandler,elStack,el,tagName,selfClosed){
 	}
 	var i = el.length;
 	while(i--){
+		a = el[i];
 		var prefix = a.prefix;
 		if(prefix){//no prefix attribute has no namespace
 			if(prefix === 'xml'){

--- a/test/dom/attr.js
+++ b/test/dom/attr.js
@@ -31,6 +31,10 @@ wows.describe('XML attrs').addBatch({
 //    	root.firstChild.setAttributeNode(root.attributes[0]);
 //    	console.assert(root.attributes.length == 0);
     },
+    "attribute namespace":function(){
+    	var root = new DOMParser().parseFromString("<xml xmlns:a='a' xmlns:b='b' a:b='e'></xml>",'text/xml').documentElement;
+    	console.assert(root.getAttributeNS("a", "b"), "e");
+    },
     "override ns attribute":function(){
     	
     },


### PR DESCRIPTION
Namespace declarations take effect immediately in XML affecting the current element and attributes. The current implementation did not appear to apply namespaces to the attributes belonging to the same element in which the namespace was declared.

Upon inspecting the code, the loop that is supposed to perform this assignment does not actually loop through the attribute array. It increments a index, but it does update the local variable used to reference the attribute in the attribute list at the index.

With this commit, the local variable is updated. A test has been added to the DOM attributes test suite to ensure that namespaces are applied to attributes immediately.
