### PR TITLE
`setNamedItemNS` leaks to global namespace.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -208,7 +208,7 @@ NamedNodeMap.prototype = {
 	},
 	/* returns Node */
 	setNamedItemNS: function(attr) {// raises: WRONG_DOCUMENT_ERR,NO_MODIFICATION_ALLOWED_ERR,INUSE_ATTRIBUTE_ERR
-		var el = attr.ownerElement;
+		var el = attr.ownerElement, oldAttr;
 		if(el && el!=this._ownerElement){
 			el.removeAttributeNode(attr);
 		}


### PR DESCRIPTION
The `oldAttr` variable in `setNamedItemNS` leaks to the global namespace. With this commit, an `oldAttr` variable is declared within `setNamedItemNS`.
