### PR TITLE
`setAttribute` now sets `localName`.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -646,6 +646,7 @@ Document.prototype = {
 		node.ownerDocument	= this;
 		node.name = name;
 		node.nodeName	= name;
+		node.localName = name;
 		node.specified = true;
 		return node;
 	},

--- a/test/dom/attr.js
+++ b/test/dom/attr.js
@@ -6,6 +6,7 @@ wows.describe('XML attrs').addBatch({
     "set attribute":function(){
     	var root = new DOMParser().parseFromString("<xml/>",'text/xml').documentElement;
     	root.setAttribute('a','1');
+    	console.assert(root.attributes[0].localName == 'a');
     	root.setAttribute('b',2);
     	root.setAttribute('a',1);
     	root.setAttribute('a',1);


### PR DESCRIPTION
Addresses the issue in #17. Fixes both `Attr.setAttribute` and `Document.createAttribute`.
