### PR TITLE
getElementsByTagName includes documentElement.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -117,7 +117,7 @@ function LiveNodeList(node,refresh){
 	_updateLiveList(this);
 }
 function _updateLiveList(list){
-	var inc = list._node.ownerDocument._inc;
+	var inc = list._node._inc || list._node.ownerDocument._inc;
 	if(list._inc != inc){
 		var ls = list._refresh(list._node);
 		//console.log(ls.length)
@@ -760,7 +760,7 @@ Element.prototype = {
 	},
 	
 	getElementsByTagName : function(tagName){
-		return new LiveNodeList(this.documentElement || this,function(base){
+		return new LiveNodeList(this,function(base){
 			var ls = [];
 			_visitNode(base,function(node){
 				if(node !== base && node.nodeType == ELEMENT_NODE && (tagName === '*' || node.tagName == tagName)){
@@ -771,7 +771,7 @@ Element.prototype = {
 		});
 	},
 	getElementsByTagNameNS : function(namespaceURI, localName){
-		return new LiveNodeList(this.documentElement || this,function(base){
+		return new LiveNodeList(this,function(base){
 			var ls = [];
 			_visitNode(base,function(node){
 				if(node !== base && node.nodeType === ELEMENT_NODE && node.namespaceURI === namespaceURI && (localName === '*' || node.localName == localName)){

--- a/test/dom/element.js
+++ b/test/dom/element.js
@@ -3,6 +3,12 @@ var DOMParser = require('xmldom').DOMParser;
 var XMLSerializer = require('xmldom').XMLSerializer;
 // Create a Test Suite
 wows.describe('XML Namespace Parse').addBatch({
+    // See: http://jsfiddle.net/bigeasy/ShcXP/1/
+    "Document_getElementsByTagName":function () {
+    	var doc = new DOMParser().parseFromString('<a><b/></a>');
+    	console.assert(doc.getElementsByTagName('*').length == 2);
+    	console.assert(doc.documentElement.getElementsByTagName('*').length == 1);
+    },
     'getElementsByTagName': function () { 
     	
 
@@ -50,7 +56,7 @@ wows.describe('XML Namespace Parse').addBatch({
        console.assert(childs.length==6,childs.length);
        
         var childs = doc.getElementsByTagNameNS("http://test.com",'*');
-       console.assert(childs.length==6,childs.length);
+       console.assert(childs.length==7,childs.length);
        
        
        var childs = doc.documentElement.getElementsByTagNameNS("http://test.com",'test');
@@ -116,6 +122,5 @@ wows.describe('XML Namespace Parse').addBatch({
     "nested append failed":function(){
     },
     "self append failed":function(){
-    	
     }
 }).run(); // Run it


### PR DESCRIPTION
When using `Document.getElementsByTagName` the `documentElement` is included in the item list if it matches the search conditions.

Closes #26.
