### PR TITLE
Encode ">" to &gt; during serialization

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -946,9 +946,9 @@ function serializeToString(node,buf){
 		}
 		return;
 	case ATTRIBUTE_NODE:
-		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
+		return buf.push(' ',node.name,'="',node.value.replace(/[<>&"]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
-		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
+		return buf.push(node.data.replace(/[<>&]/g,_xmlEncoder));
 	case CDATA_SECTION_NODE:
 		return buf.push( '<![CDATA[',node.data,']]>');
 	case COMMENT_NODE:


### PR DESCRIPTION
Symbol ">" is not properly encoded during serialization.

Test code:

``` javascript
var xmldom = require('xmldom');
var domparser = new xmldom.DOMParser;
var xmlserializer = new xmldom.XMLSerializer;

var dom = domparser.parseFromString('<node attr="&lt;&gt;">&lt;&gt;</node>');
var s = xmlserializer.serializeToString(dom);
console.log(s);

// outputs '<node attr="&lt;>">&lt;></node>'
```
