### PR TITLE
Fixing bug: DOCTYPE was being stripped by parseFromString

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -431,7 +431,7 @@ function parseDCC(source,start,domBuilder){//sure start with '<!'
 			//error
 			return -1;
 		}
-	case '[':
+	default:
 		if(source.substr(start+3,6) == 'CDATA['){
 			var end = source.indexOf(']]>',start+9);
 			domBuilder.startCDATA();


### PR DESCRIPTION
This commit resolves a bug which caused the DOCTYPE to be stripped by
DOMParser().parseFromString when parsing HTML documents. The following
test case was used (run in Node.js):

var xmldom = require('xmldom'),
    DOMParser = xmldom.DOMParser,
    XMLSerializer = new xmldom.XMLSerializer(),
    string = '<!doctype
html><html><head></head><body>content</body></html>',
    doc = new DOMParser().parseFromString(string, 'text/html'),
    s = XMLSerializer,
    str = s.serializeToString(doc);
console.log(str);

I'm not sure if my commit is the best way to fix the bug or not, but it seems to work. :)
