### PR TITLE
Fix insert of empty DocumentFragment.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -501,6 +501,9 @@ function _insertBefore(parentNode,newChild,nextChild){
 	}
 	if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
 		var newFirst = newChild.firstChild;
+		if (newFirst == null) {
+			return newChild;
+		}
 		var newLast = newChild.lastChild;
 	}else{
 		newFirst = newLast = newChild;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "contributors": [
     {"name" : "Yaron Naveh","email" : "yaronn01@gmail.com","web" : "http://webservices20.blogspot.com/"},
     {"name" : "Harutyun Amirjanyan","email" : "amirjanyan@gmail.com","web" : "https://github.com/nightwing"},
-    {"name" : "bigeasy","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
+    {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
   ],
   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},
   "licenses": [{"type": "LGPL","url": "http://www.gnu.org/licenses/lgpl.html"}]

--- a/test/dom/fragment.js
+++ b/test/dom/fragment.js
@@ -1,0 +1,15 @@
+var wows = require('vows');
+var DOMParser = require('xmldom').DOMParser;
+var XMLSerializer = require('xmldom').XMLSerializer;
+
+wows.describe('DOM DocumentFragment').addBatch({
+	// see: http://jsfiddle.net/9Wmh2/1/
+	"append empty fragment":function(){
+		var document = new DOMParser().parseFromString('<p id="p"/>');
+		var fragment = document.createDocumentFragment();
+		document.getElementById("p").insertBefore(fragment, null);
+		fragment.appendChild(document.createTextNode("a"));
+		document.getElementById("p").insertBefore(fragment, null);
+		console.assert(document.toString() == '<p id="p">a</p>', document.toString());
+	},
+}).run();


### PR DESCRIPTION
When inserting an empty `DocumentFragment` a null refererence exception is thrown. I've edited the internal `insertBefore` implementation to detect an empty `DocumentFragment` and return early.

To test this insertion, I created a new test script for `DocumentFragment` tests. If there are future tests of `DocumentFragment` specific logic, then can go there.

Updated the `bigeasy` contributor entry to the full name of said contributor.
