### PR TITLE
Avoid excessive quoting of DOCTYPE attributes

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -957,8 +957,8 @@ function serializeToString(node,buf){
 	case COMMENT_NODE:
 		return buf.push( "<!--",node.data,"-->");
 	case DOCUMENT_TYPE_NODE:
-		var pubid = node.publicId;
-		var sysid = node.systemId;
+		var pubid = node.publicId.replace(/"/g,'');
+		var sysid = node.systemId.replace(/"/g,'');
 		buf.push('<!DOCTYPE ',node.name);
 		if(pubid){
 			buf.push(' PUBLIC "',pubid);


### PR DESCRIPTION
DOCTYPE attributes are already double-quoted so the additional double quotes applied in the PUBLIC and SYSTEM strings were resulting in un-parseable output. This patch ensures existing double quotes are stripped.
