### PR TITLE
Double double quotes

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -961,11 +961,11 @@ function serializeToString(node,buf){
 		var sysid = node.systemId;
 		buf.push('<!DOCTYPE ',node.name);
 		if(pubid){
-			buf.push(' PUBLIC "',pubid);
+			buf.push(' PUBLIC ',pubid);
 			if (sysid && sysid!='.') {
-				buf.push( '" "',sysid);
+				buf.push( ' ',sysid);
 			}
-			buf.push('">');
+			buf.push('>');
 		}else if(sysid && sysid!='.'){
 			buf.push(' SYSTEM "',sysid,'">');
 		}else{


### PR DESCRIPTION
After recently updating xmldom to newest version I have started getting bad XML on the output in the form of

```
<!DOCTYPE svg PUBLIC ""-//W3C//DTD SVG 1.1//EN"" ""http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"">
```

Note the double double-quotes. I am not sure if my commit does not break anything else ... anyhow - please take take a look! Thanks for a useful module.
