### PR TITLE
Fix for parseFromString throwing error when given plain text to parse

### DIFF
--- a/dom-parser.js
+++ b/dom-parser.js
@@ -86,6 +86,12 @@ DOMHandler.prototype = {
         	this.document.documentURI = this.locator.systemId;
     	}
 	},
+	allText:function(source) {
+		var doc = this.document;
+	    var el = doc.createTextNode(source);
+	    appendElement(this, el);
+	    this.currentElement = el;
+	},
 	startElement:function(namespaceURI, localName, qName, attrs) {
 		var doc = this.document;
 	    var el = doc.createElementNS(namespaceURI, qName||localName);

--- a/sax.js
+++ b/sax.js
@@ -115,7 +115,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 		default:
 			if(i<0){
 				if(!source.substr(start).match(/^\s*$/)){
-					errorHandler.error('source code out of document root');
+					domBuilder.allText(source);
 				}
 				return;
 			}else{


### PR DESCRIPTION
This pull request resolves the following issue: https://github.com/jindw/xmldom/issues/69
