### PR TITLE
.npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test
+t
+travis.yml
+.project
+changelog


### PR DESCRIPTION
Tests and changelog aren't needed when publishing to npm. It's just a waste of space and bandwidth.
