### PR TITLE
TypeError when Document is created with DocumentType

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -267,12 +267,12 @@ DOMImplementation.prototype = {
 	// Introduced in DOM Level 2:
 	createDocument:function(namespaceURI,  qualifiedName, doctype){// raises:INVALID_CHARACTER_ERR,NAMESPACE_ERR,WRONG_DOCUMENT_ERR
 		var doc = new Document();
+		doc.implementation = this;
+		doc.childNodes = new NodeList();
 		doc.doctype = doctype;
 		if(doctype){
 			doc.appendChild(doctype);
 		}
-		doc.implementation = this;
-		doc.childNodes = new NodeList();
 		if(qualifiedName){
 			var root = doc.createElementNS(namespaceURI,qualifiedName);
 			doc.appendChild(root);


### PR DESCRIPTION
Example of error:

``` js
var xmldom = require('xmldom');
var impl = new xmldom.DOMImplementation();

var doctype = impl.createDocumentType('svg', '-//W3C//DTD SVG 1.1//EN', 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd');
var doc = impl.createDocument('http://www.w3.org/2000/svg', 'svg', doctype);

console.log((new xmldom.XMLSerializer).serializeToString(doc));
```

Throws:

```
/Users/ing/Sites/xmldom/dom.js:462
                cs[i++] = child;

TypeError: Cannot set property '0' of null
    at _onUpdateChild (/Users/ing/Sites/xmldom/dom.js:462:13)
    at _insertBefore (/Users/ing/Sites/xmldom/dom.js:530:2)
    at Document.insertBefore (/Users/ing/Sites/xmldom/dom.js:580:10)
    at Document.Node.appendChild (/Users/ing/Sites/xmldom/dom.js:334:15)
    at Object.DOMImplementation.createDocument (/Users/ing/Sites/xmldom/dom.js:272:8)
    at Object.<anonymous> (/Users/ing/Sites/sprites/src/lib/test.js:5:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```
