### PR TITLE
convert attribute's value to string in setAttributeNS

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -759,7 +759,7 @@ Element.prototype = {
 	},
 	setAttributeNS : function(namespaceURI, qualifiedName, value){
 		var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);
-		attr.value = attr.nodeValue = value;
+		attr.value = attr.nodeValue = "" + value;
 		this.setAttributeNode(attr)
 	},
 	getAttributeNodeNS : function(namespaceURI, localName){


### PR DESCRIPTION
If setAttributeNS is used with non-string attribute values, we can be in trouble when we e.g. try to serialize the XML :

TypeError: Object 11900 has no method 'replace'
    at serializeToString ([...]/node_modules/xmldom/dom.js:952:49)
    at serializeToString ([...]/xmldom/dom.js:923:4)
    at serializeToString ([...]/node_modules/xmldom/dom.js:947:4)
    at XMLSerializer.serializeToString ([...]/node_modules/xmldom/dom.js:907:2)
    at Document.Node.toString ([...]/node_modules/xmldom/dom.js:911:33)
    [...]

This is already done in setAttribute.
