### PR TITLE
Removing leading whitespace from text nodes

### DIFF
--- a/dom-parser.js
+++ b/dom-parser.js
@@ -132,7 +132,7 @@ DOMHandler.prototype = {
 				var charNode = this.document.createCDATASection(chars);
 				this.currentElement.appendChild(charNode);
 			} else {
-				var charNode = this.document.createTextNode(chars);
+				var charNode = this.document.createTextNode(chars.replace(/^\s+/, '')); // removing leading whitespace to be more consistent with browser DOMParser
 				this.currentElement.appendChild(charNode);
 			}
 			this.locator && position(this.locator,charNode)


### PR DESCRIPTION
This behavior is more consistent with standard XML parsing as I understand it. (e.g. http://www.usingxml.com/Basics/XmlSpace)

Note: only removing the _leading_ whitespace and not the trailing whitespace because web browser implementations of DOMParser preserve trailing whitespace.
