### PR TITLE
Added '*' NS support for getElementsByTagNameNS

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -781,7 +781,7 @@ Element.prototype = {
 		return new LiveNodeList(this,function(base){
 			var ls = [];
 			_visitNode(base,function(node){
-				if(node !== base && node.nodeType === ELEMENT_NODE && node.namespaceURI === namespaceURI && (localName === '*' || node.localName == localName)){
+				if(node !== base && node.nodeType === ELEMENT_NODE && (namespaceURI === '*' || node.namespaceURI === namespaceURI) && (localName === '*' || node.localName == localName)){
 					ls.push(node);
 				}
 			});

--- a/test/dom/element.js
+++ b/test/dom/element.js
@@ -55,9 +55,8 @@ wows.describe('XML Namespace Parse').addBatch({
        var childs = doc.documentElement.getElementsByTagNameNS("http://test.com",'*');
        console.assert(childs.length==6,childs.length);
        
-        var childs = doc.getElementsByTagNameNS("http://test.com",'*');
+       var childs = doc.getElementsByTagNameNS("http://test.com",'*');
        console.assert(childs.length==7,childs.length);
-       
        
        var childs = doc.documentElement.getElementsByTagNameNS("http://test.com",'test');
        console.assert(childs.length==3,childs.length);
@@ -65,7 +64,11 @@ wows.describe('XML Namespace Parse').addBatch({
        var childs = doc.getElementsByTagNameNS("http://test.com",'test');
        console.assert(childs.length==3,childs.length);
        
-       
+       var childs = doc.getElementsByTagNameNS("*, "test);
+       console.assert(childs.length==3,childs.length);
+
+       var childs = doc.documentElement.getElementsByTagNameNS("*, "test);
+       console.assert(childs.length==3,childs.length);
        
     },
     'getElementById': function () { 


### PR DESCRIPTION
This is a fix for Issue#61, which allows specifying Element#getElementsByTagNameNS('*', '{tagName}') to get all tags of a given name regardless of namespaceURI.
