### PR TITLE
Calling toString on node.value incase typeof(node.value) !== string.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -949,7 +949,7 @@ function serializeToString(node,buf){
 		}
 		return;
 	case ATTRIBUTE_NODE:
-		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
+		return buf.push(' ',node.name,'="',node.value.toString().replace(/[<&"]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
 		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
 	case CDATA_SECTION_NODE:


### PR DESCRIPTION
fixes #121 - When `typeof(node.value)` is not a string, calling `replace` on it throws an error. In my specific case, `node.value` was being reported as a `number`. Calling `.toString()` on the object ensures that we're dealing with a string when calling `replace`.