### PR TITLE
Added find() and findOne() methods to Element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /.proof.out
+.idea/

--- a/dom.js
+++ b/dom.js
@@ -787,10 +787,106 @@ Element.prototype = {
 			});
 			return ls;
 		});
-	}
+	},
+    find: function(elementName, ns, conditionCallback) {
+        var dummyResults = new FindResult([this]);
+        return dummyResults.find(elementName, ns, conditionCallback);
+    },
+    findOne: function(elementName, ns, conditionCallback) {
+        var dummyResult = new FindOneResult(this);
+        return dummyResult.findOne(elementName, ns, conditionCallback);
+    }
 };
 Document.prototype.getElementsByTagName = Element.prototype.getElementsByTagName;
 Document.prototype.getElementsByTagNameNS = Element.prototype.getElementsByTagNameNS;
+
+function currentIsMatch(current, elementName, ns, conditionCallback) {
+    var isMatch = current.localName == elementName;
+
+    if (ns && current.namespaceURI != ns) {
+        isMatch = false;
+    }
+
+    if (conditionCallback && !conditionCallback(current, x)) {
+        isMatch = false;
+    }
+
+    return isMatch;
+}
+
+function FindOneResult(result) {
+    this.result = result;
+};
+
+FindOneResult.prototype = {
+    findOne: function(elementName, ns, conditionCallback) {
+        var results = [];
+
+        if (this.result) {
+            for (var x = 0; x < this.result.childNodes.length; x++) {
+                var current = this.result.childNodes[x];
+
+                if (currentIsMatch(current, elementName, ns, conditionCallback)) {
+                    results.push(current);
+                }
+            }
+        }
+
+        return new FindOneResult(results.length == 1 ? results[0] : null);
+    },
+    find: function(elementName, ns, conditionCallback) {
+        var results = [];
+
+        if (this.result) {
+            for (var x = 0; x < this.result.childNodes.length; x++) {
+                var current = this.result.childNodes[x];
+
+                if (currentIsMatch(current, elementName, ns, conditionCallback)) {
+                    results.push(current);
+                }
+            }
+        }
+
+        return new FindResult(results);
+    }
+};
+
+function FindResult(results) {
+    this.results = results;
+};
+
+FindResult.prototype = {
+    find: function(elementName, ns, conditionCallback) {
+        var results = [];
+
+        for (var i = 0; i < this.results.length; i++) {
+            for (var x = 0; x < this.results[i].childNodes.length; x++ ) {
+                var current = this.results[i].childNodes[x];
+
+                if (currentIsMatch(current, elementName, ns, conditionCallback)) {
+                    results.push(current);
+                }
+            }
+        }
+
+        return new FindResult(results);
+    },
+    findOne: function(elementName, ns, conditionCallback) {
+        var results = [];
+
+        for (var i = 0; i < this.results.length; i++) {
+            for (var x = 0; x < this.results[i].childNodes.length; x++ ) {
+                var current = this.results[i].childNodes[x];
+
+                if (currentIsMatch(current, elementName, ns, conditionCallback)) {
+                    results.push(current);
+                }
+            }
+        }
+
+        return new FindResult(results.length == 1 ? results : []);
+    }
+};
 
 
 _extends(Element,Node);

--- a/test/find.js
+++ b/test/find.js
@@ -1,0 +1,17 @@
+/**
+ * Created by Sean on 5/4/2015.
+ */
+var wows = require('vows');
+var DOMParser = require('xmldom').DOMParser;
+
+// Create a Test Suite
+wows.describe('Element find and findOne').addBatch({
+    'find': function () {
+        var data = fs.readFileSync(path.resolve(__dirname,'./test.xml'), 'ascii');
+        var doc = new DOMParser().parseFromString(data, 'text/xml');
+
+        var results = doc.documentElement
+            .find('Category')
+            .find('Data');
+    }
+});


### PR DESCRIPTION
Hi. I have been working on a fork of xmldom, to add in some functionality for more-easily finding elements. I think this would be a good addition to the main xmldom implementation...

The idea is pretty simple, you can chain .find() or .findOne() requests on Element instances, like so:

var results = doc.documentElement
  .find('myElement')
  .find('myChildElement')
  .findOne('mySingleGrandchildElement');

Please consider merging this into your master branch.

P.S. I started building a unit test for this, but couldn't figure out what framework you were using for unit tests (more specifically, how I would go about executing the unit tests). I am familiar with mocha, but not with the framework you are using.
