### PR TITLE
Fixes: TypeError: node.serializeToString is not a function

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -903,7 +903,7 @@ ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
 _extends(ProcessingInstruction,Node);
 function XMLSerializer(){}
 XMLSerializer.prototype.serializeToString = function(node,attributeSorter){
-	node.serializeToString(attributeSorter);
+	node.toString(attributeSorter);
 }
 Node.prototype.toString =function(attributeSorter){
 	var buf = [];


### PR DESCRIPTION
The following code `return new XmlDom.XMLSerializer().serializeToString(doc.documentElement);` broke in 0.1.20 (worked in 0.1.19).

```
TypeError: node.serializeToString is not a function
```

This fixes the error introduced here https://github.com/jindw/xmldom/commit/447e45eaf1c8caa8217bb069948d0fa5504b1c50

Fixes https://github.com/jindw/xmldom/issues/146