### PR TITLE
Expose node type constants

### DIFF
--- a/dom-parser.js
+++ b/dom-parser.js
@@ -253,4 +253,5 @@ if(typeof require == 'function'){
 	var DOMImplementation = exports.DOMImplementation = require('./dom').DOMImplementation;
 	exports.XMLSerializer = require('./dom').XMLSerializer ;
 	exports.DOMParser = DOMParser;
+	exports.Node = require("./dom").Node;
 }

--- a/dom.js
+++ b/dom.js
@@ -1138,4 +1138,5 @@ try{
 if(typeof require == 'function'){
 	exports.DOMImplementation = DOMImplementation;
 	exports.XMLSerializer = XMLSerializer;
+	exports.Node = Node;
 }

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,20 @@ DOM level2 method and attribute:
 ------
 
  * [Node](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247)
-	
+		 
+		const:
+			ELEMENT_NODE
+			ATTRIBUTE_NODE
+			TEXT_NODE
+			CDATA_SECTION_NODE
+			ENTITY_REFERENCE_NODE
+			ENTITY_NODE
+			PROCESSING_INSTRUCTION_NODE
+			COMMENT_NODE
+			DOCUMENT_NODE
+			DOCUMENT_TYPE_NODE
+			DOCUMENT_FRAGMENT_NODE
+			NOTATION_NODE
 		attribute:
 			nodeValue|prefix
 		readonly attribute:


### PR DESCRIPTION
This PR will expose Node's type constants which are defined in DOM level 2.
User can code the same way as in browser env.
```
var Node = require("xmldom").Node;

for (var node = xmlElem.firstChild; node !== null; node = node.nextSibling) {
  if (node.nodeType === Node.ELEMENT_NODE) {
    var elem = node;
     ...
  }
}
```