### PR TITLE
Use browser's implementation when this module is loaded by browserify

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,26 @@
+function DOMImplementation() {
+	this._impl = window.document.implementation;
+}
+
+DOMImplementation.prototype = {
+	// Always returns true.
+	// https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature
+	hasFeature: function(feature) {
+		return this._impl.hasFeature(feature);
+	},
+	
+	createDocument: function(namespaceURI,  qualifiedName, doctype) {
+		return this._impl.createDocument(namespaceURI,  qualifiedName, doctype);
+	},
+	
+	createDocumentType: function(qualifiedName, publicId, systemId) {
+		return this._impl.createDocumentType(qualifiedName, publicId, systemId);
+	}
+};
+
+module.exports = {
+	DOMImplementation: DOMImplementation,
+	XMLSerializer: window.XMLSerializer,
+	DOMParser: window.DOMParser,
+	Node: window.Node
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "homepage": "https://github.com/jindw/xmldom",
   "repository": {"type": "git","url": "git://github.com/jindw/xmldom.git"},
   "main": "./dom-parser.js",
+  "browser": "./browser.js",
   "scripts" : { "test": "proof platform win32 && proof test */*/*.t.js || t/test" },
   "engines": {"node": ">=0.1"},
   "dependencies": {},


### PR DESCRIPTION
When this module is loaded by browserify, use browser's XML implementation instead. 

Node module which depends 'xmldom' can run on Node.js and browsers.
