### PR TITLE
fix license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
   ],
   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},
-  "licenses": [{"type": "LGPL","url": "http://www.gnu.org/licenses/lgpl.html","MIT":"http://opensource.org/licenses/MIT"}]
+  "licenses": [{"type": "LGPL","url": "http://www.gnu.org/licenses/lgpl.html"},{"type": "MIT","url":"http://opensource.org/licenses/MIT"}]
 }


### PR DESCRIPTION
The old JSON structure was not parseable by tools like https://github.com/davglass/license-checker.