### PR TITLE
do consider empty lines when parsing documents

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -76,7 +76,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 	}
 	var lineStart = 0;
 	var lineEnd = 0;
-	var linePattern = /.+(?:\r\n?|\n)|.*$/g
+	var linePattern = /.*(?:\r\n?|\n)|.*$/g
 	var locator = domBuilder.locator;
 	
 	var parseStack = [{currentNSMap:defaultNSMapCopy}]


### PR DESCRIPTION
fix linenumbers when parsing documents with empty lines 

See the following example: without this fix, the example will give the wrong linenumber for the error.

Example (error in line 10: the attribut _event_ is missing the equals-symbol; the example contains 3 empty lines before line 10):
```xml
<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0"
       profile="ecmascript" id="scxmlRoot" initial="start">

  <!--
      some comment (next line is empty)

  -->

  <state id="start" name="start">
    <transition event"init" name="init" target="main_state" />
  </state>

  </scxml>

```
the error message without the FIX: 
`element parse error: Error: attribute value must after "=", @#[line:7,col:5]`

And with parsing of empty lines, the correct linenumber will be given: 
`element parse error: Error: attribute value must after "=", @#[line:10,col:5]`