### PR TITLE
Updated licence field in package.json to use SPDX Expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
   ],
   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},
-  "licenses": [{"type": "LGPL","url": "http://www.gnu.org/licenses/lgpl.html","MIT":"http://opensource.org/licenses/MIT"}]
+  "license": "(MIT OR LGPL-3.0)"
 }


### PR DESCRIPTION
The previous license field format has been deprecated by npm, and
replaced by SPDX expressions. This change will allow the licences to be
displayed on xmldom's npmjs.com page.

For more information see: https://docs.npmjs.com/files/package.json

The ordering is based on the order found in xmldom/LICENSE