### PR TITLE
fix endless loop when 'unexpected end of input'

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -246,7 +246,7 @@ function parseElementStartPart(source,start,el,entityReplacer,errorHandler){
 			break;
 		case ''://end document
 			//throw new Error('unexpected end of input')
-			errorHandler.error('unexpected end of input');
+			errorHandler.fatalError('unexpected end of input');
 		case '>':
 			switch(s){
 			case S_TAG:


### PR DESCRIPTION
``` js
var DOMParser = require('xmldom').DOMParser;

var str = '<s';
new DOMParser().parseFromString(str);
```

This test will run into an endless loop @

``` js
       // line 72 of sax.js
    function position(p,m){
        while(p>=lineEnd && (m = linePattern.exec(source))){
            lineStart = m.index;
            lineEnd = lineStart + m[0].length;
            // m.index === lineStart && m[0].length === 0
            // Nothing changes, so this loop will never end.
            locator.lineNumber++;
            //console.log('line++:',locator,startPos,endPos)
        }
        locator.columnNumber = p-lineStart+1;
    }
```

This pull request will fix this issue.
