### PR TITLE
[LICENSE] Update license in package.json to be an SPDX compatible expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
   ],
   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},
-  "licenses": [{"type": "LGPL","url": "http://www.gnu.org/licenses/lgpl.html","MIT":"http://opensource.org/licenses/MIT"}]
+  "license": "(LGPL-2.0 or MIT)"
 }


### PR DESCRIPTION
Based on the [LICENSE](https://github.com/jindw/xmldom/blob/master/LICENSE) file, it is either (LGPL or MIT) so I reflected that in the SPDX expression in the license key of package.json. See my doc references below.

I didn't know which specific LGPL license you intended, so I selected the earliest LGPL-2.0. If it is LGPL-2.1 or LGP-3.0 instead, let me know I will update this PR.

package.json license doc: https://docs.npmjs.com/files/package.json
SPDX ids: https://spdx.org/licenses/
