### PR TITLE
Use an SPDX license expression in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
   ],
   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},
-  "licenses": [{"type": "LGPL","url": "http://www.gnu.org/licenses/lgpl.html","MIT":"http://opensource.org/licenses/MIT"}]
+  "license": "(LGPL-3.0 OR MIT)"
 }


### PR DESCRIPTION
From https://docs.npmjs.com/files/package.json#license:

> Some old packages used license objects or a "licenses" property
> containing an array of license objects

This replaces that, as per:

> If your package is licensed under multiple common licenses, use an
> SPDX license expression syntax version 2.0 string

See https://npmjs.com/package/spdx for more context
