### PR TITLE
Fix strict mode syntax error

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -21,7 +21,7 @@ function _extends(Class,Super){
 		pt.__proto__ = ppt;
 	}
 	if(!(pt instanceof Super)){
-		function t(){};
+		var t = function(){};
 		t.prototype = Super.prototype;
 		t = new t();
 		copy(pt,t);
@@ -1212,8 +1212,8 @@ try{
 				}
 			}
 		})
-		
-		function getTextContent(node){
+
+		var getTextContent = function(node){
 			switch(node.nodeType){
 			case ELEMENT_NODE:
 			case DOCUMENT_FRAGMENT_NODE:


### PR DESCRIPTION
I ran across this error from an embedded STB version of Opera when including this library in a rollup bundle:

"Uncaught SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function."

It was preventing the entire bundle from being loaded... these changes satisfy the parser.