### PR TITLE
Update `license` field to conform to SPDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     {"name" : "Alan Gutierrez","email" : "alan@prettyrobots.com","web" : "http://www.prettyrobots.com/"}
   ],
   "bugs": {"email": "jindw@xidea.org","url": "http://github.com/jindw/xmldom/issues"},
-  "license": "(LGPL-2.0 or MIT)"
+  "license": "(LGPL-2.0 OR MIT)"
 }


### PR DESCRIPTION
The license checker that npm uses - [spdx](https://www.npmjs.com/package/spdx) - expects the conjuctive / disjunctive operators to be capital-cased in order to parse the `license` field correctly.

```js
spdx.valid('(LGPL-2.0 or MIT)'); // => null
spdx.valid('(LGPL-2.0 OR MIT)'); // => true
```