### PR TITLE
Fix "]]>" serialization in text nodes

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -1053,7 +1053,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 	case ATTRIBUTE_NODE:
 		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
-		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
+		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder).replace(/\]\]>/g,']]'+_xmlEncoder('>')));
 	case CDATA_SECTION_NODE:
 		return buf.push( '<![CDATA[',node.data,']]>');
 	case COMMENT_NODE:

--- a/test/dom/serializer.js
+++ b/test/dom/serializer.js
@@ -5,7 +5,7 @@ wows.describe('XML Serializer').addBatch({
   'text node containing "]]>"': function() {
     var doc = new DOMParser().parseFromString('<test/>', 'text/xml');
     doc.documentElement.appendChild(doc.createTextNode('hello ]]> there'));
-    console.assert(doc.documentElement.firstChild.toString() == 'hello ]]> there',doc.documentElement.firstChild.toString());
+    console.assert(doc.documentElement.firstChild.toString() == 'hello ]]&gt; there',doc.documentElement.firstChild.toString());
   },
   '<script> element with no children': function() {
     var doc = new DOMParser({xmlns:{xmlns:'http://www.w3.org/1999/xhtml'}}).parseFromString('<html2><script></script></html2>', 'text/html');


### PR DESCRIPTION
This fixes issue #164, which is a regression caused by commit 47fa9b8.
Before, text nodes were serialized correctly (thanks to commit 22fff92).

Section 2.4 of the XML 1.0 (5th Ed) recommendation states:

    The right angle bracket (>) may be represented using the string
    "&gt;", and MUST, for compatibility, be escaped using either "&gt;"
    or a character reference when it appears in the string "]]>" in
    content, when that string is not marking the end of a CDATA section.

See https://www.w3.org/TR/2008/REC-xml-20081126/#syntax for details.

Thus, this commit escapes the right angle bracket in text nodes if it
appears as part of "]]>". If not, the right angle bracket is not
escaped.

The unittest that was broken since commit 47fa9b8 has been fixed, too.