### PR TITLE
Allow xhtml+xml in entities test

### DIFF
--- a/dom-parser.js
+++ b/dom-parser.js
@@ -10,7 +10,7 @@ DOMParser.prototype.parseFromString = function(source,mimeType){
 	var errorHandler = options.errorHandler;
 	var locator = options.locator;
 	var defaultNSMap = options.xmlns||{};
-	var isHTML = /\/x?html?$/.test(mimeType);//mimeType.toLowerCase().indexOf('html') > -1;
+	var isHTML = /\/x?html?(\+xml)?$/.test(mimeType);//mimeType.toLowerCase().indexOf('html') > -1;
   	var entityMap = isHTML?htmlEntity.entityMap:{'lt':'<','gt':'>','amp':'&','quot':'"','apos':"'"};
 	if(locator){
 		domBuilder.setDocumentLocator(locator)


### PR DESCRIPTION
xhtml is often served with the mime type of `application/xhtml+xml` which isn't picked up with the current regex. This add a check for `+xml` at then end of the regex test.

Fixes https://github.com/jindw/xmldom/pull/205