### PR TITLE
Don't treat XML declarations as Processing Instructions

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -551,8 +551,9 @@ function parseInstruction(source,start,domBuilder){
 	if(end){
 		var match = source.substring(start,end).match(/^<\?(\S*)\s*([\s\S]*?)\s*$/);
 		if(match){
-			var len = match[0].length;
-			domBuilder.processingInstruction(match[1], match[2]) ;
+			if(match[1].toLowerCase() !== 'xml'){//ignore XML declarations
+				domBuilder.processingInstruction(match[1], match[2]) ;
+			}
 			return end+2;
 		}else{//error
 			return -1;

--- a/test/dom/index.js
+++ b/test/dom/index.js
@@ -1,6 +1,7 @@
 require('./attr');
 require('./clone');
 require('./element');
+require('./pi');
 require('./fragment');
 require('./level3');
 require('./serializer');

--- a/test/dom/pi.js
+++ b/test/dom/pi.js
@@ -1,0 +1,30 @@
+var wows = require('vows');
+var DOMParser = require('xmldom').DOMParser;
+var assert = require('assert')
+var XMLSerializer = require('xmldom').XMLSerializer;
+// Create a Test Suite
+wows.describe('Processing Instruction Parse').addBatch({
+	'Generic PI': function () {
+		var doc = new DOMParser().parseFromString('<?foo bar baz?><root></root>');
+		var pi = doc.childNodes[0];
+		console.assert(doc.childNodes.length == 2);
+		console.assert(pi.nodeType == 7);
+		console.assert(pi.target == 'foo');
+		console.assert(pi.data == 'bar baz');
+	},
+	'XML stylesheet PI': function () {
+		var doc = new DOMParser().parseFromString('<?xml-stylesheet href="style.css"?><root></root>');
+		var pi = doc.childNodes[0];
+		console.assert(doc.childNodes.length == 2);
+		console.assert(pi.nodeType == 7);
+		console.assert(pi.target == 'xml-stylesheet');
+		console.assert(pi.data == 'href="style.css"');
+	},
+	'XML declaration is not a PI': function () {
+		var doc = new DOMParser().parseFromString('<?xml version="1.0"?><root></root>');
+		var elem = doc.childNodes[0];
+        console.log(doc)
+		console.assert(doc.childNodes.length == 1);
+		console.assert(elem.nodeType == 1);
+	},
+}).run(); // Run it


### PR DESCRIPTION
XML declarations are not processing instructions.
This fixes #174.

According to XML 1.0 (5th Edition), Section 2.6, the PI target names "xml",
"XML" and so on are reserved.

Production Rule 17 states:
> PITarget ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))