### PR TITLE
Don't choke on internal subset in !DOCTYPE

### DIFF
--- a/sax.js
+++ b/sax.js
@@ -603,7 +603,7 @@ ElementAttributes.prototype = {
 function split(source,start){
 	var match;
 	var buf = [];
-	var reg = /'[^']+'|"[^"]+"|[^\s<>\/=]+=?|(\/?\s*>|<)/g;
+	var reg = /'[^']+'|"[^"]+"|\[[^\]]+]|[^\s<>\/=]+=?|(\/?\s*>|<)/g;
 	reg.lastIndex = start;
 	reg.exec(source);//skip <
 	while(match = reg.exec(source)){

--- a/test/parse/node.js
+++ b/test/parse/node.js
@@ -98,7 +98,11 @@ wows.describe('XML Node Parse').addBatch({
 	    var doc = parser.parseFromString('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html/>', 'text/html');
 		console.log(doc+'')
 		
-	}
+	},
+	'internal subset':function(){
+		var doc = (new DOMParser()).parseFromString('<!DOCTYPE root [ <!ENTITY foo "<a b=\'c\'>bar</a>"> ]><root/>', 'text/xml');
+		console.assert(doc+'' == '<!DOCTYPE root><root/>', doc+'')
+	},
 }).run(); // Run it
 //var ELEMENT_NODE                = NodeType.ELEMENT_NODE                = 1;
 //var ATTRIBUTE_NODE              = NodeType.ATTRIBUTE_NODE              = 2;


### PR DESCRIPTION
Fixes #210.

**Note:** This does not add support for the [`internalSubset`](https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-Core-DocType-internalSubset) attribute of the `DocumentType` interface yet.