### PR TITLE
Fix lookupNamespaceURI / lookupPrefix for Document / Attributes.

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -368,6 +368,9 @@ Node.prototype = {
     },
     lookupPrefix:function(namespaceURI){
     	var el = this;
+    	if(el.nodeType == DOCUMENT_NODE){
+    		el = el.documentElement;
+    	}
     	while(el){
     		var map = el._nsMap;
     		//console.dir(map)
@@ -378,13 +381,16 @@ Node.prototype = {
     				}
     			}
     		}
-    		el = el.nodeType == ATTRIBUTE_NODE?el.ownerDocument : el.parentNode;
+    		el = el.nodeType == ATTRIBUTE_NODE?el.ownerElement : el.parentNode;
     	}
     	return null;
     },
     // Introduced in DOM Level 3:
     lookupNamespaceURI:function(prefix){
     	var el = this;
+    	if(el.nodeType == DOCUMENT_NODE){
+    		el = el.documentElement;
+    	}
     	while(el){
     		var map = el._nsMap;
     		//console.dir(map)
@@ -393,7 +399,7 @@ Node.prototype = {
     				return map[prefix] ;
     			}
     		}
-    		el = el.nodeType == ATTRIBUTE_NODE?el.ownerDocument : el.parentNode;
+    		el = el.nodeType == ATTRIBUTE_NODE?el.ownerElement : el.parentNode;
     	}
     	return null;
     },

--- a/test/parse/namespace.js
+++ b/test/parse/namespace.js
@@ -28,5 +28,13 @@ wows.describe('XML Namespace Parse').addBatch({
        console.assert(root.firstChild.namespaceURI=='http://p.com')
        console.assert(root.lastChild.namespaceURI=='http://test.com')
        console.assert(root.firstChild.nextSibling.lookupNamespaceURI('p') == 'http://test.com')
+    },
+    'performing a lookup from a document node': function () {
+       var documentNode = new DOMParser().parseFromString('<xml xmlns="http://test.com"/>','text/xml');
+       console.assert(documentNode.lookupNamespaceURI('') == 'http://test.com')
+    },
+    'performing a lookup from an attribute node': function () {
+    var documentNode = new DOMParser().parseFromString('<xml xmlns="http://test.com" attr="1"/>','text/xml');
+		console.assert(documentNode.documentElement.getAttributeNode('attr').lookupNamespaceURI('') == 'http://test.com')
     }
 }).run(); // Run it


### PR DESCRIPTION
This fixes #213.

I could not figure out how to run the unit tests, running `npm run test` only runs one test...
I have added two of them though, testing the changed functions.


This version better aligns with the spec (https://www.w3.org/TR/DOM-Level-3-Core/namespaces-algorithms.html#lookupNamespaceURIAlgo)