### PR TITLE
Fix newline character encoding

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -415,6 +415,7 @@ function _xmlEncoder(c){
          c == '&' && '&amp;' ||
          c == '"' && '&quot;' ||
          c == '\n' && '&#10;' ||
+         c == '&#10;' && '\n' ||
          '&#'+c.charCodeAt()+';'
 }
 
@@ -1056,7 +1057,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		}
 		return;
 	case ATTRIBUTE_NODE:
-		return buf.push(' ',node.name,'="',node.value.replace(/[<&"\n]/g,_xmlEncoder),'"');
+		return buf.push(' ',node.name,'="',node.value.replace(/&#10;|[<&"\n]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
 		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
 	case CDATA_SECTION_NODE:

--- a/dom.js
+++ b/dom.js
@@ -414,6 +414,7 @@ function _xmlEncoder(c){
          c == '>' && '&gt;' ||
          c == '&' && '&amp;' ||
          c == '"' && '&quot;' ||
+         c == '\n' && '&#10;' ||
          '&#'+c.charCodeAt()+';'
 }
 
@@ -1055,7 +1056,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		}
 		return;
 	case ATTRIBUTE_NODE:
-		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
+		return buf.push(' ',node.name,'="',node.value.replace(/[<&"\n]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
 		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
 	case CDATA_SECTION_NODE:

--- a/dom.js
+++ b/dom.js
@@ -414,8 +414,8 @@ function _xmlEncoder(c){
          c == '>' && '&gt;' ||
          c == '&' && '&amp;' ||
          c == '"' && '&quot;' ||
-         c == '\n' && '&#10;' ||
-         c == '&#10;' && '\n' ||
+         c == '\n' && '&#10;' || // encode newline correctly
+         c == '&#10;' && '&#10;' || // already correctly encoded, leave it untouched
          '&#'+c.charCodeAt()+';'
 }
 
@@ -1057,6 +1057,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		}
 		return;
 	case ATTRIBUTE_NODE:
+		// &#10; added before the other characters to avoid its & being replaced
 		return buf.push(' ',node.name,'="',node.value.replace(/&#10;|[<&"\n]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
 		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));


### PR DESCRIPTION
This library suffers from the problem described here: https://stackoverflow.com/a/2012277
Newlines are not encoded properly.
PR fix this by encoding `\n` as `&#10;` (LF) and properly decoding `&#10;` as `\n`.