### PR TITLE
Fixed namespace propagation after dom manipulation

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -1040,7 +1040,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 			buf.push('/>');
 		}
 		// remove added visible namespaces
-		//visibleNamespaces.length = startVisibleNamespaces;
+		visibleNamespaces.length = startVisibleNamespaces;
 		return;
 	case DOCUMENT_NODE:
 	case DOCUMENT_FRAGMENT_NODE:

--- a/test/dom/serializer.js
+++ b/test/dom/serializer.js
@@ -1,15 +1,39 @@
 var wows = require('vows');
-var DOMParser = require('xmldom').DOMParser;
+var assert = require('assert');
+var xmldom = require('../../dom-parser')
+var DOMParser = xmldom.DOMParser;
+var XMLSerializer = xmldom.XMLSerializer
 
 wows.describe('XML Serializer').addBatch({
-  'text node containing "]]>"': function() {
-    var doc = new DOMParser().parseFromString('<test/>', 'text/xml');
-    doc.documentElement.appendChild(doc.createTextNode('hello ]]> there'));
-    console.assert(doc.documentElement.firstChild.toString() == 'hello ]]> there',doc.documentElement.firstChild.toString());
-  },
-  '<script> element with no children': function() {
-    var doc = new DOMParser({xmlns:{xmlns:'http://www.w3.org/1999/xhtml'}}).parseFromString('<html2><script></script></html2>', 'text/html');
-    //console.log(doc.documentElement.firstChild.toString(true))
-    console.assert(doc.documentElement.firstChild.toString() == '<script></script>');
-  },
+	'text node containing "]]>"': function() {
+		var doc = new DOMParser().parseFromString('<test/>', 'text/xml');
+		doc.documentElement.appendChild(doc.createTextNode('hello ]]> there'));
+		assert.equal(doc.documentElement.firstChild.toString(), 'hello ]]> there', doc.documentElement.firstChild.toString());
+	},
+	'<script> element with no children': function() {
+		var doc = new DOMParser({xmlns: {xmlns: 'http://www.w3.org/1999/xhtml'}}).parseFromString('<html2><script></script></html2>', 'text/html');
+		assert.equal(doc.documentElement.firstChild.toString(), '<script xmlns="http://www.w3.org/1999/xhtml"></script>');
+	},
+	'namespace propagation after dom manipulation': function() {
+		var inputStr = '<o><parent xmlns:foo="bar"><foo:child></foo:child><foo:child></foo:child></parent></o>';
+		var doc = new DOMParser().parseFromString(inputStr, 'text/html');
+
+
+		//remove parent
+		var parent = doc.documentElement.getElementsByTagName("parent")[0];
+
+		var length = parent.childNodes.length;
+		for (var i = 0; i < length; i++) {
+			var obj = parent.childNodes[i];
+			parent.parentNode.appendChild(obj);
+		}
+		parent.parentNode.removeChild(parent);
+
+		//namespace should be propagated to children
+		var result = new XMLSerializer().serializeToString(doc);
+
+		var expected = '<o xmlns="http://www.w3.org/1999/xhtml"><foo:child xmlns:foo="bar"></foo:child><foo:child xmlns:foo="bar"></foo:child></o>';
+
+		assert.equal(result, expected);
+	}
 }).run();


### PR DESCRIPTION
When DOM is manipulated the namespace gets correctly propagated to all
children if their namespace was declared in the removed node instead of
only the first child.

This fixes #215 .