### PR TITLE
fixed replaceChild bug

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -522,7 +522,7 @@ function _insertBefore(parentNode,newChild,nextChild){
 	if(pre){
 		pre.nextSibling = newFirst;
 	}else{
-		parentNode.firstChild = newFirst;
+		nextChild.parentNode.firstChild = newFirst;
 	}
 	if(nextChild == null){
 		parentNode.lastChild = newLast;


### PR DESCRIPTION
```
// node: <div><slot /></div>
// newChild: Hello World
// oldChild: <slot />

node.replaceChild(newChild, oldChild);

// Expect: <div>Hello World</div>
// Actually: Hello World
```

But if I added a space befor `<slot />`, I get the correct result.

```
// node: <div> <slot /></div>
// newChild: Hello World
// oldChild: <slot />

node.replaceChild(newChild, oldChild);

// Expect: <div> Hello World</div>
// Actually: <div> Hello World</div>
```