### PR TITLE
npmignore should ignore itself and travis yml.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 test
 t
-travis.yml
+.npmignore
+.travis.yml
 .project
 changelog


### PR DESCRIPTION
Just a little bit of clean up. I noticed when I installed via npm that npmignore and travis files were being included unnecessarily.