### PR TITLE
Export DOM classes

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -1237,4 +1237,20 @@ try{
 //if(typeof require == 'function'){
 	exports.DOMImplementation = DOMImplementation;
 	exports.XMLSerializer = XMLSerializer;
+
+	exports.Attr = Attr;
+	exports.CharacterData = CharacterData;
+	exports.Comment = Comment;
+	exports.Document = Document;
+	exports.DocumentFragment = DocumentFragment;
+	exports.DOMException = DOMException;
+	exports.DOMImplementation = DOMImplementation;
+	exports.Element = Element;
+	exports.NamedNodeMap = NamedNodeMap;
+	exports.Node = Node;
+	exports.NodeList = NodeList;
+	exports.Text = Text;
+	
+	exports.ExceptionCode = ExceptionCode;
+	exports.LiveNodeList = LiveNodeList;
 //}


### PR DESCRIPTION
This exports the classes for `Document`, `DocumentFragment`, `Element`, `NodeList` and `LiveNodeList`, to allow them to be extended and modified by clients implementing this library.

Partly addresses https://github.com/jindw/xmldom/issues/235.